### PR TITLE
ISSUE-18 support of child event listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,9 @@
 \- ***GdxFIRStorage#upload*** signature has changed
 \- firebase actions chaining 
 \- shorter version of *.instance()* method: *.inst()* in all GdxFIR classes
+
+**[2.0.1]**
+\- ISSUE #16 - API Change: allows Map to be filtered
+
+**[2.1.0]**
+\- ISSUE #18 - API Addition: add new #onChildChange in database API

--- a/e2e/core/src/pl/mk5/gdx/fireapp/e2e/GdxFireappE2ETests.java
+++ b/e2e/core/src/pl/mk5/gdx/fireapp/e2e/GdxFireappE2ETests.java
@@ -16,6 +16,7 @@ import pl.mk5.gdx.fireapp.e2e.tests.AuthSignInUserEmailPasswordTest;
 import pl.mk5.gdx.fireapp.e2e.tests.AuthSignOutTest;
 import pl.mk5.gdx.fireapp.e2e.tests.BadlogicTest;
 import pl.mk5.gdx.fireapp.e2e.tests.CrashTest;
+import pl.mk5.gdx.fireapp.e2e.tests.DatabaseChildEventTest;
 import pl.mk5.gdx.fireapp.e2e.tests.DatabaseLimitEqualTest;
 import pl.mk5.gdx.fireapp.e2e.tests.DatabaseListenerValueTest;
 import pl.mk5.gdx.fireapp.e2e.tests.DatabaseReadPojoListTest;
@@ -64,6 +65,7 @@ public class GdxFireappE2ETests extends ApplicationAdapter {
         e2ETestRunner.addNext(DatabaseListenerValueTest.class, 10);
         e2ETestRunner.addNext(DatabaseReadPojoListTest.class, 10);
         e2ETestRunner.addNext(DatabaseReadPojoMapWithKeysTest.class, 10);
+        e2ETestRunner.addNext(DatabaseChildEventTest.class, 30);
 
 
         e2ETestRunner.onFinish(new Runnable() {

--- a/e2e/core/src/pl/mk5/gdx/fireapp/e2e/tests/DatabaseChildEventTest.java
+++ b/e2e/core/src/pl/mk5/gdx/fireapp/e2e/tests/DatabaseChildEventTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.e2e.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Timer;
+
+import java.util.Collections;
+import java.util.List;
+
+import pl.mk5.gdx.fireapp.GdxFIRDatabase;
+import pl.mk5.gdx.fireapp.database.ChildEventType;
+import pl.mk5.gdx.fireapp.e2e.runner.E2ETest;
+import pl.mk5.gdx.fireapp.functional.Consumer;
+
+public class DatabaseChildEventTest extends E2ETest {
+
+    private Timer.Task checkTask;
+
+    @Override
+    public void action() {
+        final Employee employee1 = new Employee("Fred", (long) Math.floor(Math.random() * 100000000));
+        final Array<String> result = new Array<>();
+
+        GdxFIRDatabase.promise()
+                .then(GdxFIRDatabase.inst().inReference("/employees").onChildChange(List.class, ChildEventType.ADDED))
+                .then(new Consumer<List>() {
+                    @Override
+                    public void accept(List list) {
+                        Gdx.app.log("ChildEventTest", "added");
+                        result.add("added");
+                    }
+                });
+
+        GdxFIRDatabase.promise()
+                .then(GdxFIRDatabase.inst().inReference("/employees").onChildChange(List.class, ChildEventType.CHANGED))
+                .then(new Consumer<List>() {
+                    @Override
+                    public void accept(List list) {
+                        Gdx.app.log("ChildEventTest", "changed");
+                        result.add("changed");
+                    }
+                });
+
+        GdxFIRDatabase.promise()
+                .then(GdxFIRDatabase.inst().inReference("/employees").onChildChange(List.class, ChildEventType.REMOVED))
+                .then(new Consumer<List>() {
+                    @Override
+                    public void accept(List list) {
+                        Gdx.app.log("ChildEventTest", "removed");
+                        result.add("removed");
+                    }
+                });
+
+        GdxFIRDatabase.promise()
+                .then(GdxFIRDatabase.inst().inReference("/employees").push().setValue(employee1))
+                .then(GdxFIRDatabase.inst().inReference("/employees/1").setValue(employee1))
+                .then(GdxFIRDatabase.inst().inReference("/employees/1").updateChildren(Collections.<String, Object>singletonMap("name", "Johnny")))
+                .then(GdxFIRDatabase.inst().inReference("/employees").removeValue());
+
+
+        checkTask = Timer.schedule(new Timer.Task() {
+            @Override
+            public void run() {
+                if (result.contains("changed", true)
+                        && result.contains("removed", true)
+                        && result.contains("added", true)) {
+                    checkTask.cancel();
+                    success();
+                }
+            }
+        }, 1f, 1f);
+    }
+
+    @Override
+    public void draw(Batch batch) {
+
+    }
+
+    @Override
+    public void update(float dt) {
+
+    }
+
+    @Override
+    public void dispose() {
+        if (checkTask != null) {
+            checkTask.cancel();
+        }
+    }
+
+    private static class Employee {
+        public String name;
+        public Long salary;
+
+        public Employee() {
+        }
+
+        public Employee(String name, Long salary) {
+            this.name = name;
+            this.salary = salary;
+        }
+
+    }
+}

--- a/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/DataSnapshotResolver.java
+++ b/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/DataSnapshotResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.android.database;
+
+import com.badlogic.gdx.utils.reflect.ClassReflection;
+import com.google.firebase.database.DataSnapshot;
+
+import java.util.Collections;
+import java.util.List;
+
+import pl.mk5.gdx.fireapp.promises.ConverterPromise;
+
+class DataSnapshotResolver {
+
+    private final Class dataType;
+    private final ConverterPromise promise;
+
+    DataSnapshotResolver(Class dataType, ConverterPromise promise) {
+        this.dataType = dataType;
+        this.promise = promise;
+    }
+
+    void resolve(DataSnapshot dataSnapshot) {
+        if (ClassReflection.isAssignableFrom(List.class, dataType) && dataSnapshot.getValue() == null) {
+            promise.doComplete(Collections.emptyList());
+        } else if (ClassReflection.isAssignableFrom(List.class, dataType)
+                && ResolverDataSnapshotList.shouldResolveOrderBy(dataType, dataSnapshot)) {
+            promise.doComplete(ResolverDataSnapshotList.resolve(dataSnapshot));
+        } else {
+            promise.doComplete(dataSnapshot.getValue());
+        }
+    }
+
+    public ConverterPromise getPromise() {
+        return promise;
+    }
+}

--- a/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/Database.java
+++ b/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/Database.java
@@ -161,7 +161,7 @@ public class Database implements DatabaseDistribution {
                 new QueryOnChildChange<>(Database.this, getDatabasePath())
                         .with(getFilters())
                         .with(getOrderByClause())
-                        .with((FuturePromise<Object>) trConverterPromise) // TODO - suppose to be wrong cast here?
+                        .with((FuturePromise<Object>) trConverterPromise)
                         .withArgs(dataType, eventsType)
                         .execute();
             }

--- a/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/QueryOnChildChange.java
+++ b/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/QueryOnChildChange.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.android.database;
+
+import com.google.firebase.database.ChildEventListener;
+import com.google.firebase.database.Query;
+
+import pl.mk5.gdx.fireapp.database.ChildEventType;
+import pl.mk5.gdx.fireapp.database.validators.ArgumentsValidator;
+import pl.mk5.gdx.fireapp.database.validators.OnChildValidator;
+import pl.mk5.gdx.fireapp.promises.ConverterPromise;
+import pl.mk5.gdx.fireapp.promises.FutureListenerPromise;
+
+/**
+ * Provides call to {@link Query#addChildEventListener(ChildEventListener)}}.
+ */
+class QueryOnChildChange<R> extends AndroidDatabaseQuery<R> {
+
+    QueryOnChildChange(Database databaseDistribution, String databasePath) {
+        super(databaseDistribution, databasePath);
+    }
+
+    @Override
+    protected ArgumentsValidator createArgumentsValidator() {
+        return new OnChildValidator();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected R run() {
+        SnapshotChildEventListener childEventListener = new SnapshotChildEventListener((Class) arguments.get(0), (ChildEventType[]) arguments.get(1), (ConverterPromise) promise);
+        filtersProvider.applyFiltering().addChildEventListener(childEventListener);
+        ((FutureListenerPromise) promise).onCancel(new CancelListenerAction(childEventListener, query));
+        return null;
+    }
+
+    private static class CancelListenerAction implements Runnable {
+
+        private final ChildEventListener listener;
+        private final Query query;
+
+        private CancelListenerAction(ChildEventListener listener, Query query) {
+            this.listener = listener;
+            this.query = query;
+        }
+
+        @Override
+        public void run() {
+            query.removeEventListener(listener);
+        }
+    }
+}

--- a/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/SnapshotChildEventListener.java
+++ b/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/SnapshotChildEventListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.android.database;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.badlogic.gdx.utils.Array;
+import com.google.firebase.database.ChildEventListener;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+
+import pl.mk5.gdx.fireapp.database.ChildEventType;
+import pl.mk5.gdx.fireapp.promises.ConverterPromise;
+
+class SnapshotChildEventListener implements ChildEventListener {
+
+    private final DataSnapshotResolver dataSnapshotResolver;
+    private final Array<ChildEventType> eventTypes;
+
+    SnapshotChildEventListener(Class dataType, ChildEventType[] eventTypes, ConverterPromise promise) {
+        this.dataSnapshotResolver = new DataSnapshotResolver(dataType, promise);
+        this.eventTypes = new Array<>(eventTypes);
+    }
+
+    @Override
+    public void onChildAdded(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+        if (!eventTypes.contains(ChildEventType.ADDED, true)) return;
+        dataSnapshotResolver.resolve(dataSnapshot);
+    }
+
+    @Override
+    public void onChildChanged(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+        if (!eventTypes.contains(ChildEventType.CHANGED, true)) return;
+        dataSnapshotResolver.resolve(dataSnapshot);
+    }
+
+    @Override
+    public void onChildRemoved(@NonNull DataSnapshot dataSnapshot) {
+        if (!eventTypes.contains(ChildEventType.REMOVED, true)) return;
+        dataSnapshotResolver.resolve(dataSnapshot);
+    }
+
+    @Override
+    public void onChildMoved(@NonNull DataSnapshot dataSnapshot, @Nullable String s) {
+        if (!eventTypes.contains(ChildEventType.MOVED, true)) return;
+        dataSnapshotResolver.resolve(dataSnapshot);
+    }
+
+    @Override
+    public void onCancelled(@NonNull DatabaseError databaseError) {
+        dataSnapshotResolver.getPromise().doFail(databaseError.toException());
+    }
+}

--- a/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/SnapshotValueListener.java
+++ b/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/database/SnapshotValueListener.java
@@ -18,40 +18,27 @@ package pl.mk5.gdx.fireapp.android.database;
 
 import android.support.annotation.NonNull;
 
-import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.ValueEventListener;
-
-import java.util.Collections;
-import java.util.List;
 
 import pl.mk5.gdx.fireapp.promises.ConverterPromise;
 
 class SnapshotValueListener implements ValueEventListener {
 
-    private Class dataType;
-    private ConverterPromise promise;
+    private DataSnapshotResolver dataSnapshotResolver;
 
     SnapshotValueListener(Class dataType, ConverterPromise promise) {
-        this.promise = promise;
-        this.dataType = dataType;
+        this.dataSnapshotResolver = new DataSnapshotResolver(dataType, promise);
     }
 
     @Override
     public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
-        if (ClassReflection.isAssignableFrom(List.class, dataType) && dataSnapshot.getValue() == null) {
-            promise.doComplete(Collections.emptyList());
-        } else if (ClassReflection.isAssignableFrom(List.class, dataType)
-                && ResolverDataSnapshotList.shouldResolveOrderBy(dataType, dataSnapshot)) {
-            promise.doComplete(ResolverDataSnapshotList.resolve(dataSnapshot));
-        } else {
-            promise.doComplete(dataSnapshot.getValue());
-        }
+        dataSnapshotResolver.resolve(dataSnapshot);
     }
 
     @Override
     public void onCancelled(@NonNull DatabaseError databaseError) {
-        promise.doFail(databaseError.toException());
+        dataSnapshotResolver.getPromise().doFail(databaseError.toException());
     }
 }

--- a/gdx-fireapp-android/src/test/java/pl/mk5/gdx/fireapp/android/database/DataSnapshotResolverTest.groovy
+++ b/gdx-fireapp-android/src/test/java/pl/mk5/gdx/fireapp/android/database/DataSnapshotResolverTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.android.database
+
+import com.google.firebase.database.DataSnapshot
+import pl.mk5.gdx.fireapp.promises.ConverterPromise
+import spock.lang.Specification
+
+class DataSnapshotResolverTest extends Specification {
+
+    def "should resolve empty list"() {
+        given:
+        def promise = Spy(ConverterPromise)
+        def resolver = new DataSnapshotResolver(List.class, promise)
+        def dataSnapshot = Mock(DataSnapshot)
+
+        when:
+        resolver.resolve(dataSnapshot)
+
+        then:
+        1 * promise.doComplete(Collections.emptyList())
+    }
+
+    def "should resolve data"() {
+        given:
+        def promise = Spy(ConverterPromise)
+        def resolver = new DataSnapshotResolver(Map.class, promise)
+        def dataSnapshot = Mock(DataSnapshot)
+        dataSnapshot.value >> "abc"
+
+        when:
+        resolver.resolve(dataSnapshot)
+
+        then:
+        1 * promise.doComplete("abc")
+    }
+
+}

--- a/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/GdxFIRDatabase.java
+++ b/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/GdxFIRDatabase.java
@@ -18,6 +18,7 @@ package pl.mk5.gdx.fireapp;
 
 import java.util.Map;
 
+import pl.mk5.gdx.fireapp.database.ChildEventType;
 import pl.mk5.gdx.fireapp.database.ConnectionStatus;
 import pl.mk5.gdx.fireapp.database.FilterType;
 import pl.mk5.gdx.fireapp.database.FirebaseMapConverter;
@@ -100,6 +101,14 @@ public class GdxFIRDatabase extends PlatformDistributor<DatabaseDistribution> im
     @Override
     public <T, E extends T> ListenerPromise<E> onDataChange(Class<T> dataType) {
         return platformObject.onDataChange(dataType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T, R extends T> ListenerPromise<R> onChildChange(Class<T> dataType, ChildEventType... eventsType) {
+        return platformObject.onChildChange(dataType, eventsType);
     }
 
     /**

--- a/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/database/ChildEventType.java
+++ b/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/database/ChildEventType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.database;
+
+/**
+ * OnChildXXX events.
+ * <p>
+ * https://firebase.google.com/docs/reference/android/com/google/firebase/database/ChildEventListener
+ */
+public enum ChildEventType {
+    ADDED,
+    CHANGED,
+    MOVED,
+    REMOVED
+}

--- a/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/database/validators/OnChildValidator.java
+++ b/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/database/validators/OnChildValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.database.validators;
+
+
+import com.badlogic.gdx.utils.Array;
+
+import pl.mk5.gdx.fireapp.database.ChildEventType;
+import pl.mk5.gdx.fireapp.distributions.DatabaseDistribution;
+
+/**
+ * Validates arguments for {@link DatabaseDistribution#onChildChange(Class, ChildEventType...)} }
+ */
+public class OnChildValidator implements ArgumentsValidator {
+
+    private static final String MESSAGE1 = "Database#onChildChange needs at least one argument";
+    private static final String MESSAGE2 = "The first argument should be class type";
+    private static final String MESSAGE3 = "The first argument should be class type";
+
+    @Override
+    public void validate(Array<Object> arguments) {
+        if (arguments.size < 1)
+            throw new IllegalArgumentException(MESSAGE1);
+        if (!(arguments.get(0) instanceof Class))
+            throw new IllegalArgumentException(MESSAGE2);
+        if (!(arguments.get(1) instanceof ChildEventType[]))
+            throw new IllegalArgumentException(MESSAGE3);
+    }
+}

--- a/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/database/validators/OnChildValidator.java
+++ b/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/database/validators/OnChildValidator.java
@@ -29,7 +29,7 @@ public class OnChildValidator implements ArgumentsValidator {
 
     private static final String MESSAGE1 = "Database#onChildChange needs at least one argument";
     private static final String MESSAGE2 = "The first argument should be class type";
-    private static final String MESSAGE3 = "The first argument should be class type";
+    private static final String MESSAGE3 = "The second argument should be ChildEventType[]";
 
     @Override
     public void validate(Array<Object> arguments) {

--- a/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/distributions/DatabaseDistribution.java
+++ b/gdx-fireapp-core/src/pl/mk5/gdx/fireapp/distributions/DatabaseDistribution.java
@@ -18,6 +18,7 @@ package pl.mk5.gdx.fireapp.distributions;
 
 import java.util.Map;
 
+import pl.mk5.gdx.fireapp.database.ChildEventType;
 import pl.mk5.gdx.fireapp.database.ConnectionStatus;
 import pl.mk5.gdx.fireapp.database.FilterType;
 import pl.mk5.gdx.fireapp.database.MapConverter;
@@ -62,7 +63,7 @@ public interface DatabaseDistribution {
      * Sets value for path given by {@code inReference(String)}.
      *
      * @param value Any value which you want to store. Given object will be transformed to Firebase-like data type.
-     * @throws RuntimeException if {@link #inReference(String)} was not call after.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
      */
     Promise<Void> setValue(Object value);
 
@@ -72,27 +73,38 @@ public interface DatabaseDistribution {
      * POJO objects received from each platform should be represented as Map.
      * Conversion will be guarantee later by {@link MapConverter}
      *
-     * @param dataType Class you want to retrieve
+     * @param dataType Class you want to retrieve, not null
      * @param <T>      Type of data you want to retrieve, associated with {@code dataType} for ex. {@code List.class}
      * @param <R>      More specific type of data you want - should be not-abstract type.
-     * @throws RuntimeException if {@link #inReference(String)} was not call after.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
      */
     <T, R extends T> Promise<R> readValue(Class<T> dataType);
 
     /**
-     * Handles value changes for path given by {@code inReference(String)}.
+     * Listen for value changes in given path.
      * <p>
      * Remember to set database reference earlier by calling the {@link #inReference(String)} method.
      * <p>
      * POJO objects received from each platform should be represented as Map. Conversion will be guarantee later by {@link MapConverter}
      * <p>
      *
-     * @param dataType Class you want to retrieve
+     * @param dataType Class you want to retrieve, not null
      * @param <T>      Type of data you want to retrieve, associated with {@code dataType} for ex. {@code List.class}
      * @param <R>      More specific type of data you want to retrieve - should be not-abstract type.
-     * @throws RuntimeException if {@link #inReference(String)} was not call after.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
      */
     <T, R extends T> ListenerPromise<R> onDataChange(Class<T> dataType);
+
+    /**
+     * Listen for child changes in given path.
+     *
+     * @param dataType   Class you want to retrieve, not null
+     * @param eventsType List of listening events, api will listen for all types of events, may be empty
+     * @param <T>        Type of data you want to retrieve, associated with {@code dataType} for ex. {@code List.class}
+     * @param <R>        More specific type of data you want to retrieve - should be not-abstract type.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
+     */
+    <T, R extends T> ListenerPromise<R> onChildChange(Class<T> dataType, ChildEventType... eventsType);
 
     /**
      * Applies filter to the next database query.
@@ -152,7 +164,7 @@ public interface DatabaseDistribution {
      * Remember to set database reference earlier by calling the {@link #inReference(String)} method.
      *
      * @param data New data
-     * @throws RuntimeException if {@link #inReference(String)} was not call after.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
      */
     Promise<Void> updateChildren(Map<String, Object> data);
 
@@ -166,7 +178,7 @@ public interface DatabaseDistribution {
      *
      * @param dataType            Type of data you want to get, not null
      * @param transactionFunction Function to modify transaction data, not null
-     * @throws RuntimeException if {@link #inReference(String)} was not call after call this method.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
      */
     <T, R extends T> Promise<Void> transaction(Class<T> dataType, Function<R, R> transactionFunction);
 
@@ -187,7 +199,7 @@ public interface DatabaseDistribution {
      * Remember to set database reference earlier by calling the {@link #inReference(String)} method.
      *
      * @param synced If true sync for specified database path will be enabled
-     * @throws RuntimeException if {@link #inReference(String)} was not call after call this method.
+     * @throws RuntimeException if {@link #inReference(String)} has not been called before
      */
     void keepSynced(boolean synced);
 }

--- a/gdx-fireapp-core/tests/groovy/pl/mk5/gdx/fireapp/GdxFIRDatabaseTest.groovy
+++ b/gdx-fireapp-core/tests/groovy/pl/mk5/gdx/fireapp/GdxFIRDatabaseTest.groovy
@@ -19,6 +19,7 @@ package pl.mk5.gdx.fireapp
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
 import pl.mk5.gdx.fireapp.GdxFIRDatabase
+import pl.mk5.gdx.fireapp.database.ChildEventType
 import pl.mk5.gdx.fireapp.database.FilterType
 import pl.mk5.gdx.fireapp.database.OrderByMode
 import pl.mk5.gdx.fireapp.distributions.DatabaseDistribution
@@ -51,6 +52,7 @@ class GdxFIRDatabaseTest extends Specification {
         gdxFIRDatabase.removeValue()
         gdxFIRDatabase.transaction(String.class, _ as Function)
         gdxFIRDatabase.updateChildren(_ as Map)
+        gdxFIRDatabase.onChildChange(String.class, ChildEventType.ADDED, ChildEventType.MOVED)
 
         then:
         1 * distribution.filter(FilterType.END_AT, _ as Object[])
@@ -64,5 +66,6 @@ class GdxFIRDatabaseTest extends Specification {
         1 * distribution.removeValue()
         1 * distribution.transaction(String.class, _ as Function)
         1 * distribution.updateChildren(_ as Map)
+        1 * distribution.onChildChange(String.class, ChildEventType.ADDED, ChildEventType.MOVED)
     }
 }

--- a/gdx-fireapp-core/tests/groovy/pl/mk5/gdx/fireapp/database/validators/OnChildValidatorTest.groovy
+++ b/gdx-fireapp-core/tests/groovy/pl/mk5/gdx/fireapp/database/validators/OnChildValidatorTest.groovy
@@ -25,9 +25,11 @@ class OnChildValidatorTest extends Specification {
     def "should pass valid arguments"() {
         given:
         def validator = new OnChildValidator()
+        def eventType = new ChildEventType[1]
+        eventType[0] = ChildEventType.CHANGED
 
         when:
-        validator.validate(new Array<Object>({ String.class { ChildEventType.CHANGED } }))
+        validator.validate(new Array<Object>(Arrays.asList(String.class, eventType).toArray()))
 
         then:
         notThrown(IllegalArgumentException)
@@ -38,12 +40,12 @@ class OnChildValidatorTest extends Specification {
         def validator = new OnChildValidator()
 
         when:
-        validator.validate(new Array<Object>({ String.class { ChildEventType.CHANGED } }))
+        validator.validate(arguments)
 
         then:
-        notThrown(IllegalArgumentException)
+        thrown(IllegalArgumentException)
 
         where:
-        arguments << [new Array<Object>({ "abc" }), new Array<Object>({ String.class "abcdef" })]
+        arguments << [new Array<Object>(Arrays.asList("abc", "absds").toArray())]
     }
 }

--- a/gdx-fireapp-core/tests/groovy/pl/mk5/gdx/fireapp/database/validators/OnChildValidatorTest.groovy
+++ b/gdx-fireapp-core/tests/groovy/pl/mk5/gdx/fireapp/database/validators/OnChildValidatorTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.database.validators
+
+import com.badlogic.gdx.utils.Array
+import pl.mk5.gdx.fireapp.database.ChildEventType
+import spock.lang.Specification
+
+class OnChildValidatorTest extends Specification {
+
+    def "should pass valid arguments"() {
+        given:
+        def validator = new OnChildValidator()
+
+        when:
+        validator.validate(new Array<Object>({ String.class { ChildEventType.CHANGED } }))
+
+        then:
+        notThrown(IllegalArgumentException)
+    }
+
+    def "should not allow wrong arguments"(Array<Object> arguments) {
+        given:
+        def validator = new OnChildValidator()
+
+        when:
+        validator.validate(new Array<Object>({ String.class { ChildEventType.CHANGED } }))
+
+        then:
+        notThrown(IllegalArgumentException)
+
+        where:
+        arguments << [new Array<Object>({ "abc" }), new Array<Object>({ String.class "abcdef" })]
+    }
+}

--- a/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/Database.java
+++ b/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/Database.java
@@ -137,8 +137,19 @@ public class Database implements DatabaseDistribution {
     }
 
     @Override
-    public <T, R extends T> ListenerPromise<R> onChildChange(Class<T> dataType, ChildEventType... eventsType) {
-        return null;
+    public <T, R extends T> ListenerPromise<R> onChildChange(final Class<T> dataType, final ChildEventType... eventsType) {
+        return ConverterPromise.whenWithConvert(new DatabaseConsumer<ConverterPromise<T, R>>(databaseReference(), orderByClause, filters) {
+            @Override
+            public void accept(ConverterPromise<T, R> rConverterPromise) {
+                rConverterPromise.with(GdxFIRDatabase.instance().getMapConverter(), dataType);
+                new QueryOnChildChange(Database.this, getDatabasePath())
+                        .with(getFilters())
+                        .with(getOrderByClause())
+                        .with(rConverterPromise)
+                        .withArgs(dataType, eventsType)
+                        .execute();
+            }
+        });
     }
 
     /**

--- a/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/Database.java
+++ b/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/Database.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.utils.Array;
 import java.util.Map;
 
 import pl.mk5.gdx.fireapp.GdxFIRDatabase;
+import pl.mk5.gdx.fireapp.database.ChildEventType;
 import pl.mk5.gdx.fireapp.database.ConnectionStatus;
 import pl.mk5.gdx.fireapp.database.DatabaseConsumer;
 import pl.mk5.gdx.fireapp.database.Filter;
@@ -133,6 +134,11 @@ public class Database implements DatabaseDistribution {
                         .execute();
             }
         });
+    }
+
+    @Override
+    public <T, R extends T> ListenerPromise<R> onChildChange(Class<T> dataType, ChildEventType... eventsType) {
+        return null;
     }
 
     /**

--- a/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/QueryOnChildChange.java
+++ b/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/QueryOnChildChange.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.html.database;
+
+import com.badlogic.gdx.utils.Array;
+
+import pl.mk5.gdx.fireapp.database.ChildEventType;
+import pl.mk5.gdx.fireapp.database.validators.ArgumentsValidator;
+import pl.mk5.gdx.fireapp.database.validators.OnChildValidator;
+import pl.mk5.gdx.fireapp.promises.FutureListenerPromise;
+import pl.mk5.gdx.fireapp.promises.FuturePromise;
+
+class QueryOnChildChange extends GwtDatabaseQuery {
+
+    private static final String CHILD_ADDED = "child_added";
+    private static final String CHILD_REMOVED = "child_removed";
+    private static final String CHILD_CHANGED = "child_changed";
+    private static final String CHILD_MOVED = "child_moved";
+
+    QueryOnChildChange(Database databaseDistribution, String databasePath) {
+        super(databaseDistribution, databasePath);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void runJS() {
+        Array<ChildEventType> childEventTypes = new Array<>((ChildEventType[]) arguments.get(1));
+        for (ChildEventType type : childEventTypes) {
+            String jsEventName = getJsEventName(type);
+            if (!GwtDataPromisesManager.hasPromise(databasePath + jsEventName)) {
+                GwtDataPromisesManager.addDataPromise(databasePath, new JsonDataPromise((Class) arguments.get(0), (FuturePromise) promise));
+                onEvent(databasePath, jsEventName, databaseReference);
+                ((FutureListenerPromise) promise).onCancel(new CancelListenerAction(databasePath, jsEventName));
+            }
+        }
+    }
+
+    @Override
+    protected ArgumentsValidator createArgumentsValidator() {
+        return new OnChildValidator();
+    }
+
+    private String getJsEventName(ChildEventType eventType) {
+        switch (eventType) {
+            case ADDED:
+                return CHILD_ADDED;
+            case CHANGED:
+                return CHILD_CHANGED;
+            case MOVED:
+                return CHILD_MOVED;
+            case REMOVED:
+                return CHILD_REMOVED;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * Attaches listener from {@link GwtDataPromisesManager} to given reference.
+     */
+    public static native void onEvent(String reference, String event, DatabaseReference databaseReference) /*-{
+         var ref = reference;
+         var orderByCalled = databaseReference.orderByCalled_;
+         $wnd.valueListenersOrderByCalled = $wnd.valueListenersOrderByCalled || {};
+         $wnd.valueListenersOrderByCalled[reference] = orderByCalled;
+         $wnd.valueListeners = $wnd.valueListeners || {};
+         $wnd.valueListeners[reference] = databaseReference.on(event, function(snap){
+           var val;
+           if( !$wnd.valueListenersOrderByCalled[reference] ){
+             val = JSON.stringify(snap.val());
+           }else{
+             var tmp = [];
+             snap.forEach(function(child){
+               tmp.push(child.val());
+             });
+             val = JSON.stringify(tmp);
+          }
+          @pl.mk5.gdx.fireapp.html.database.GwtDataPromisesManager::callPromise(Ljava/lang/String;Ljava/lang/String;)(ref+event,val);
+        });
+    }-*/;
+
+    /**
+     * Remove value listeners for given path.
+     */
+    public static native void offEvent(String reference, String event) /*-{
+        $wnd.valueListeners = $wnd.valueListeners || {};
+        $wnd.valueListenersOrderByCalled = $wnd.valueListenersOrderByCalled || {};
+        $wnd.valueListenersOrderByCalled[reference] = false;
+        var listener = $wnd.valueListeners[reference] || null;
+        $wnd.firebase.database().ref(reference).off(event, listener);
+        @pl.mk5.gdx.fireapp.html.database.GwtDataPromisesManager::removeDataPromise(Ljava/lang/String;)(reference+event);
+    }-*/;
+
+    private static class CancelListenerAction implements Runnable {
+
+        private final String databasePath;
+        private final String event;
+
+        private CancelListenerAction(String databasePath, String event) {
+            this.databasePath = databasePath;
+            this.event = event;
+        }
+
+        @Override
+        public void run() {
+            offEvent(databasePath, event);
+        }
+    }
+}

--- a/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/QueryOnChildChange.java
+++ b/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/QueryOnChildChange.java
@@ -38,7 +38,8 @@ class QueryOnChildChange extends GwtDatabaseQuery {
     @Override
     @SuppressWarnings("unchecked")
     protected void runJS() {
-        Array<ChildEventType> childEventTypes = new Array<>((ChildEventType[]) arguments.get(1));
+        Array<ChildEventType> childEventTypes = new Array<>();
+        childEventTypes.addAll((ChildEventType[]) arguments.get(1));
         for (ChildEventType type : childEventTypes) {
             String jsEventName = getJsEventName(type);
             if (!GwtDataPromisesManager.hasPromise(databasePath + jsEventName)) {

--- a/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/QueryOnDataChange.java
+++ b/gdx-fireapp-html/src/pl/mk5/gdx/fireapp/html/database/QueryOnDataChange.java
@@ -21,9 +21,6 @@ import pl.mk5.gdx.fireapp.database.validators.OnDataValidator;
 import pl.mk5.gdx.fireapp.promises.FutureListenerPromise;
 import pl.mk5.gdx.fireapp.promises.FuturePromise;
 
-/**
- * Provides setValue execution.
- */
 class QueryOnDataChange extends GwtDatabaseQuery {
 
     QueryOnDataChange(Database databaseDistribution, String databasePath) {

--- a/gdx-fireapp-html/tests/pl/mk5/gdx/fireapp/html/database/DatabaseTest.java
+++ b/gdx-fireapp-html/tests/pl/mk5/gdx/fireapp/html/database/DatabaseTest.java
@@ -45,6 +45,8 @@ import pl.mk5.gdx.fireapp.promises.FuturePromise;
 import pl.mk5.gdx.fireapp.promises.Promise;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
 
 @PrepareForTest({ScriptRunner.class, QueryConnectionStatus.class,
         QuerySetValue.class, QueryReadValue.class, QueryOnDataChange.class, QueryPush.class,
@@ -61,10 +63,10 @@ public class DatabaseTest {
 
     @Before
     public void setUp() throws Exception {
-        PowerMockito.mockStatic(ClassReflection.class);
-        PowerMockito.mockStatic(DatabaseReference.class);
-        PowerMockito.mockStatic(ScriptRunner.class);
-        PowerMockito.mockStatic(GwtDataPromisesManager.class);
+        mockStatic(ClassReflection.class);
+        mockStatic(DatabaseReference.class);
+        mockStatic(ScriptRunner.class);
+        mockStatic(GwtDataPromisesManager.class);
         PowerMockito.when(ScriptRunner.class, "firebaseScript", Mockito.any(Runnable.class)).then(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) {
@@ -81,8 +83,8 @@ public class DatabaseTest {
     public void onConnect() throws Exception {
         // Given
         Database database = new Database();
-        PowerMockito.mockStatic(QueryConnectionStatus.class);
-        QueryConnectionStatus queryConnectionStatus = PowerMockito.spy(new QueryConnectionStatus(database));
+        mockStatic(QueryConnectionStatus.class);
+        QueryConnectionStatus queryConnectionStatus = spy(new QueryConnectionStatus(database));
         PowerMockito.whenNew(QueryConnectionStatus.class).withAnyArguments().thenReturn(queryConnectionStatus);
 
         // When
@@ -112,8 +114,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QuerySetValue.class);
-        QuerySetValue query = PowerMockito.spy(new QuerySetValue(database, testReference));
+        mockStatic(QuerySetValue.class);
+        QuerySetValue query = spy(new QuerySetValue(database, testReference));
         PowerMockito.whenNew(QuerySetValue.class).withAnyArguments().thenReturn(query);
         String testValue = "test_value";
 
@@ -131,8 +133,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryReadValue.class);
-        QueryReadValue query = PowerMockito.spy(new QueryReadValue(database, testReference));
+        mockStatic(QueryReadValue.class);
+        QueryReadValue query = spy(new QueryReadValue(database, testReference));
         PowerMockito.whenNew(QueryReadValue.class).withAnyArguments().thenReturn(query);
         Gdx.app = Mockito.mock(Application.class);
         Class dataType = String.class;
@@ -152,8 +154,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryOnDataChange.class);
-        QueryOnDataChange query = PowerMockito.spy(new QueryOnDataChange(database, testReference));
+        mockStatic(QueryOnDataChange.class);
+        QueryOnDataChange query = spy(new QueryOnDataChange(database, testReference));
         PowerMockito.whenNew(QueryOnDataChange.class).withAnyArguments().thenReturn(query);
         Gdx.app = Mockito.mock(Application.class);
         PowerMockito.doReturn(false).when(GwtDataPromisesManager.class, "hasPromise", testReference);
@@ -173,8 +175,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryOnChildChange.class);
-        QueryOnChildChange query = PowerMockito.spy(new QueryOnChildChange(database, testReference));
+        mockStatic(QueryOnChildChange.class);
+        QueryOnChildChange query = spy(new QueryOnChildChange(database, testReference));
         PowerMockito.whenNew(QueryOnChildChange.class).withAnyArguments().thenReturn(query);
         Gdx.app = Mockito.mock(Application.class);
         PowerMockito.doReturn(false).when(GwtDataPromisesManager.class, "hasPromise", testReference + "child_added");
@@ -185,7 +187,7 @@ public class DatabaseTest {
                 .onChildChange(dataType, ChildEventType.ADDED).subscribe()).doComplete(testReference);
 
         // Then
-        PowerMockito.verifyStatic(QueryOnDataChange.class);
+        PowerMockito.verifyStatic(QueryOnChildChange.class);
         QueryOnChildChange.onEvent(eq(testReference), eq("child_added"), Mockito.any(DatabaseReference.class));
     }
 
@@ -194,8 +196,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryOnDataChange.class);
-        QueryOnDataChange query = PowerMockito.spy(new QueryOnDataChange(database, testReference));
+        mockStatic(QueryOnDataChange.class);
+        QueryOnDataChange query = spy(new QueryOnDataChange(database, testReference));
         PowerMockito.whenNew(QueryOnDataChange.class).withAnyArguments().thenReturn(query);
         PowerMockito.doReturn(false).when(GwtDataPromisesManager.class, "hasPromise", testReference);
         GwtDataPromisesManager.removeDataPromise(testReference);
@@ -218,8 +220,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryPush.class);
-        QueryPush query = PowerMockito.spy(new QueryPush(database, testReference));
+        mockStatic(QueryPush.class);
+        QueryPush query = spy(new QueryPush(database, testReference));
         PowerMockito.whenNew(QueryPush.class).withAnyArguments().thenReturn(query);
 
         // When
@@ -236,8 +238,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryRemoveValue.class);
-        QueryRemoveValue query = PowerMockito.spy(new QueryRemoveValue(database, testReference));
+        mockStatic(QueryRemoveValue.class);
+        QueryRemoveValue query = spy(new QueryRemoveValue(database, testReference));
         PowerMockito.whenNew(QueryRemoveValue.class).withAnyArguments().thenReturn(query);
 
         // When
@@ -253,8 +255,8 @@ public class DatabaseTest {
         // Given
         String testReference = "test_reference";
         Database database = new Database();
-        PowerMockito.mockStatic(QueryUpdateChildren.class);
-        QueryUpdateChildren query = PowerMockito.spy(new QueryUpdateChildren(database, testReference));
+        mockStatic(QueryUpdateChildren.class);
+        QueryUpdateChildren query = spy(new QueryUpdateChildren(database, testReference));
         PowerMockito.whenNew(QueryUpdateChildren.class).withAnyArguments().thenReturn(query);
         Map data = Mockito.mock(Map.class);
 
@@ -272,8 +274,8 @@ public class DatabaseTest {
         String testReference = "test_reference";
         Database database = new Database();
         Function function = Mockito.mock(Function.class);
-        PowerMockito.mockStatic(QueryRunTransaction.class);
-        QueryRunTransaction query = PowerMockito.spy(new QueryRunTransaction(database, testReference));
+        mockStatic(QueryRunTransaction.class);
+        QueryRunTransaction query = spy(new QueryRunTransaction(database, testReference));
         PowerMockito.whenNew(QueryRunTransaction.class).withAnyArguments().thenReturn(query);
         Class dataType = Long.class;
 

--- a/gdx-fireapp-ios-moe/src/pl/mk5/gdx/fireapp/ios/database/Database.java
+++ b/gdx-fireapp-ios-moe/src/pl/mk5/gdx/fireapp/ios/database/Database.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import bindings.google.firebasedatabase.FIRDatabase;
 import bindings.google.firebasedatabase.FIRDatabaseReference;
 import pl.mk5.gdx.fireapp.GdxFIRDatabase;
+import pl.mk5.gdx.fireapp.database.ChildEventType;
 import pl.mk5.gdx.fireapp.database.ConnectionStatus;
 import pl.mk5.gdx.fireapp.database.DatabaseConsumer;
 import pl.mk5.gdx.fireapp.database.Filter;
@@ -143,6 +144,13 @@ public class Database implements DatabaseDistribution {
                         .execute();
             }
         });
+    }
+
+    @Override
+    public <T, R extends T> ListenerPromise<R> onChildChange(Class<T> dataType, ChildEventType... eventsType) {
+        checkReference();
+        FilteringStateEnsurer.checkFilteringState(filters, orderByClause, dataType);
+        return null;
     }
 
     /**

--- a/gdx-fireapp-ios-moe/src/pl/mk5/gdx/fireapp/ios/database/Database.java
+++ b/gdx-fireapp-ios-moe/src/pl/mk5/gdx/fireapp/ios/database/Database.java
@@ -135,7 +135,7 @@ public class Database implements DatabaseDistribution {
         return ConverterPromise.whenWithConvert(new DatabaseConsumer<ConverterPromise<T, R>>(databasePath, orderByClause, filters) {
             @Override
             public void accept(ConverterPromise<T, R> rFuturePromise) {
-                rFuturePromise.with(GdxFIRDatabase.instance().getMapConverter(), dataType);
+                rFuturePromise.with(GdxFIRDatabase.inst().getMapConverter(), dataType);
                 new QueryOnDataChange(Database.this, getDatabasePath())
                         .with(getFilters())
                         .with(getOrderByClause())
@@ -147,10 +147,21 @@ public class Database implements DatabaseDistribution {
     }
 
     @Override
-    public <T, R extends T> ListenerPromise<R> onChildChange(Class<T> dataType, ChildEventType... eventsType) {
+    public <T, R extends T> ListenerPromise<R> onChildChange(final Class<T> dataType, final ChildEventType... eventsType) {
         checkReference();
         FilteringStateEnsurer.checkFilteringState(filters, orderByClause, dataType);
-        return null;
+        return ConverterPromise.whenWithConvert(new DatabaseConsumer<ConverterPromise<T, R>>(databasePath, orderByClause, filters) {
+            @Override
+            public void accept(ConverterPromise<T, R> rFuturePromise) {
+                rFuturePromise.with(GdxFIRDatabase.inst().getMapConverter(), dataType);
+                new QueryOnChildChange<>(Database.this, getDatabasePath())
+                        .with(getFilters())
+                        .with(getOrderByClause())
+                        .with((FuturePromise<Object>) rFuturePromise)
+                        .withArgs(dataType, eventsType)
+                        .execute();
+            }
+        });
     }
 
     /**

--- a/gdx-fireapp-ios-moe/src/pl/mk5/gdx/fireapp/ios/database/QueryOnChildChange.java
+++ b/gdx-fireapp-ios-moe/src/pl/mk5/gdx/fireapp/ios/database/QueryOnChildChange.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 mk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.mk5.gdx.fireapp.ios.database;
+
+import com.badlogic.gdx.utils.Array;
+
+import bindings.google.firebasedatabase.FIRDatabaseQuery;
+import bindings.google.firebasedatabase.enums.FIRDataEventType;
+import pl.mk5.gdx.fireapp.database.ChildEventType;
+import pl.mk5.gdx.fireapp.database.validators.ArgumentsValidator;
+import pl.mk5.gdx.fireapp.database.validators.OnChildValidator;
+import pl.mk5.gdx.fireapp.promises.ConverterPromise;
+import pl.mk5.gdx.fireapp.promises.FutureListenerPromise;
+
+/**
+ * Provides call to {@link FIRDatabaseQuery#observeEventTypeWithBlockWithCancelBlock(long, FIRDatabaseQuery.Block_observeEventTypeWithBlockWithCancelBlock_1, FIRDatabaseQuery.Block_observeEventTypeWithBlockWithCancelBlock_2)}.
+ */
+class QueryOnChildChange<R> extends IosDatabaseQuery<R> {
+
+    QueryOnChildChange(Database databaseDistribution, String databasePath) {
+        super(databaseDistribution, databasePath);
+    }
+
+    @Override
+    protected ArgumentsValidator createArgumentsValidator() {
+        return new OnChildValidator();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected R run() {
+        Array<ChildEventType> childEventTypes = new Array<>((ChildEventType[]) arguments.get(1));
+        for (ChildEventType type : childEventTypes) {
+            long databaseType = getDatabaseEventType(type);
+            long handle = filtersProvider.applyFiltering().observeEventTypeWithBlockWithCancelBlock(databaseType,
+                    new SnapshotProcessorBlock((ConverterPromise) promise, orderByClause, (Class) arguments.get(0)),
+                    new SnapshotCancelBlock((ConverterPromise) promise));
+            ((FutureListenerPromise) promise).onCancel(new CancelAction(handle, query));
+        }
+        return null;
+    }
+
+    private long getDatabaseEventType(ChildEventType childEventType) {
+        switch (childEventType) {
+            case ADDED:
+                return FIRDataEventType.ChildAdded;
+            case CHANGED:
+                return FIRDataEventType.ChildChanged;
+            case MOVED:
+                return FIRDataEventType.ChildMoved;
+            case REMOVED:
+                return FIRDataEventType.ChildRemoved;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private static class CancelAction implements Runnable {
+
+        private final long handle;
+        private final FIRDatabaseQuery query;
+
+        private CancelAction(long handle, FIRDatabaseQuery query) {
+            this.handle = handle;
+            this.query = query;
+        }
+
+        @Override
+        public void run() {
+            query.removeObserverWithHandle(handle);
+        }
+    }
+}

--- a/gdx-fireapp-ios-moe/tests/pl/mk5/gdx/fireapp/ios/database/DatabaseTest.java
+++ b/gdx-fireapp-ios-moe/tests/pl/mk5/gdx/fireapp/ios/database/DatabaseTest.java
@@ -36,7 +36,9 @@ import apple.foundation.NSString;
 import bindings.google.firebasedatabase.FIRDatabase;
 import bindings.google.firebasedatabase.FIRDatabaseQuery;
 import bindings.google.firebasedatabase.FIRDatabaseReference;
+import bindings.google.firebasedatabase.enums.FIRDataEventType;
 import pl.mk5.gdx.fireapp.GdxFIRDatabase;
+import pl.mk5.gdx.fireapp.database.ChildEventType;
 import pl.mk5.gdx.fireapp.database.Filter;
 import pl.mk5.gdx.fireapp.database.FilterType;
 import pl.mk5.gdx.fireapp.database.MapConverter;
@@ -218,6 +220,29 @@ public class DatabaseTest extends GdxIOSAppTest {
 //      PowerMockito.verifyNew(OnDataChangeQuery.class).withArguments(Mockito.any());
 //      Mockito.verify(query, VerificationModeFactory.times(1)).execute();
         Mockito.verify(firDatabaseReference, VerificationModeFactory.times(1)).removeObserverWithHandle(Mockito.eq(handleValue));
+    }
+
+    @Test
+    public void onChildChange() throws Exception {
+        // Given
+        Database database = new Database();
+        mockStatic(QueryOnChildChange.class);
+        QueryOnChildChange query = PowerMockito.spy(new QueryOnChildChange(database, "/test"));
+        GdxFIRDatabase gdxFIRDatabase = mock(GdxFIRDatabase.class);
+        when(gdxFIRDatabase.getMapConverter()).thenReturn(mock(MapConverter.class));
+        when(GdxFIRDatabase.instance()).thenReturn(mock(GdxFIRDatabase.class));
+        whenNew(QueryOnChildChange.class).withAnyArguments().thenReturn(query);
+        Class dataType = String.class;
+
+        // When
+        database.inReference("/test").onChildChange(dataType, ChildEventType.CHANGED).subscribe();
+
+        // Then
+        Mockito.verify(firDatabaseReference, VerificationModeFactory.times(1)).observeEventTypeWithBlockWithCancelBlock(
+                Mockito.eq(FIRDataEventType.ChildChanged),
+                Mockito.any(FIRDatabaseQuery.Block_observeEventTypeWithBlockWithCancelBlock_1.class),
+                Mockito.any(FIRDatabaseQuery.Block_observeEventTypeWithBlockWithCancelBlock_2.class)
+        );
     }
 
     @Test

--- a/gdx-fireapp-ios-moe/tests/pl/mk5/gdx/fireapp/ios/database/DatabaseTest.java
+++ b/gdx-fireapp-ios-moe/tests/pl/mk5/gdx/fireapp/ios/database/DatabaseTest.java
@@ -180,7 +180,7 @@ public class DatabaseTest extends GdxIOSAppTest {
         QueryOnDataChange query = PowerMockito.spy(new QueryOnDataChange(database, "/test"));
         GdxFIRDatabase gdxFIRDatabase = mock(GdxFIRDatabase.class);
         when(gdxFIRDatabase.getMapConverter()).thenReturn(mock(MapConverter.class));
-        when(GdxFIRDatabase.instance()).thenReturn(mock(GdxFIRDatabase.class));
+        when(GdxFIRDatabase.inst()).thenReturn(mock(GdxFIRDatabase.class));
         whenNew(QueryOnDataChange.class).withAnyArguments().thenReturn(query);
         Class dataType = String.class;
 
@@ -202,7 +202,7 @@ public class DatabaseTest extends GdxIOSAppTest {
         long handleValue = 10L;
         GdxFIRDatabase gdxFIRDatabase = mock(GdxFIRDatabase.class);
         when(gdxFIRDatabase.getMapConverter()).thenReturn(mock(MapConverter.class));
-        when(GdxFIRDatabase.instance()).thenReturn(mock(GdxFIRDatabase.class));
+        when(GdxFIRDatabase.inst()).thenReturn(mock(GdxFIRDatabase.class));
         when(firDatabaseReference.observeEventTypeWithBlockWithCancelBlock(
                 anyLong(),
                 any(FIRDatabaseQuery.Block_observeEventTypeWithBlockWithCancelBlock_1.class),
@@ -230,7 +230,7 @@ public class DatabaseTest extends GdxIOSAppTest {
         QueryOnChildChange query = PowerMockito.spy(new QueryOnChildChange(database, "/test"));
         GdxFIRDatabase gdxFIRDatabase = mock(GdxFIRDatabase.class);
         when(gdxFIRDatabase.getMapConverter()).thenReturn(mock(MapConverter.class));
-        when(GdxFIRDatabase.instance()).thenReturn(mock(GdxFIRDatabase.class));
+        when(GdxFIRDatabase.inst()).thenReturn(mock(GdxFIRDatabase.class));
         whenNew(QueryOnChildChange.class).withAnyArguments().thenReturn(query);
         Class dataType = String.class;
 


### PR DESCRIPTION
Add the new `onChildChange` method to the database API.  
Example of usage:

```
GdxFIRDatabase.inst().inReference("/employees")
.onChildChange(List.class, ChildEventType.ADDED)
```