### PR TITLE
Allow logEvent from Analytics to log events with numeric parameters

### DIFF
--- a/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/analytics/Analytics.java
+++ b/gdx-fireapp-android/src/main/java/pl/mk5/gdx/fireapp/android/analytics/Analytics.java
@@ -17,7 +17,6 @@
 package pl.mk5.gdx.fireapp.android.analytics;
 
 import android.os.Bundle;
-import android.text.TextUtils;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.android.AndroidApplication;
@@ -45,9 +44,9 @@ public class Analytics implements AnalyticsDistribution {
             bundle = new Bundle();
             for (String key : params.keySet()) {
                 String value = params.get(key);
-                if (TextUtils.isDigitsOnly(value)) {
+                try {
                     BundleHelper.putNumberParam(bundle, key, value);
-                } else {
+                } catch (IllegalArgumentException e) {
                     bundle.putString(key, value);
                 }
             }

--- a/gdx-fireapp-android/src/test/java/pl/mk5/gdx/fireapp/android/TestUtils.java
+++ b/gdx-fireapp-android/src/test/java/pl/mk5/gdx/fireapp/android/TestUtils.java
@@ -1,0 +1,39 @@
+package pl.mk5.gdx.fireapp.android;
+
+import android.os.Bundle;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class TestUtils {
+    // Copied from https://stackoverflow.com/a/13238729
+    public static boolean equalBundles(Bundle one, Bundle two) {
+        if(one.size() != two.size())
+            return false;
+
+        Set<String> setOne = new HashSet<>(one.keySet());
+        setOne.addAll(two.keySet());
+        Object valueOne;
+        Object valueTwo;
+
+        for(String key : setOne) {
+            if (!one.containsKey(key) || !two.containsKey(key))
+                return false;
+
+            valueOne = one.get(key);
+            valueTwo = two.get(key);
+            if(valueOne instanceof Bundle && valueTwo instanceof Bundle &&
+                    !equalBundles((Bundle) valueOne, (Bundle) valueTwo)) {
+                return false;
+            }
+            else if(valueOne == null) {
+                if(valueTwo != null)
+                    return false;
+            }
+            else if(!valueOne.equals(valueTwo))
+                return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
On iOS this was previously not supported in gdx-fireapp and on Android the code contained a bug.

The bug on Android was that `TextUtils.isDigitsOnly()` prevents non integers from being parsed as doubles/floats because of the decimal point. It also prevents longs from being parsed as the parsing method expects a trailing `l`