### PR TITLE
How about enable Gradle Configuration on Demand feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx1500m
-org.gradle.configureondemand=false
+org.gradle.configureondemand=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION

[Configuration on demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:configuration_on_demand). Configuration on demand tells Gradle to configure modules that only are relevant to the requested tasks instead of configuring all of them. We can enable this feature by setting `org.gradle.configureondemand=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
