### PR TITLE
Fix Signin with apple, by passing correct IdToken, and validating aga…

### DIFF
--- a/gdx-fireapp-ios/src/pl/mk5/gdx/fireapp/ios/auth/AppleAuth.java
+++ b/gdx-fireapp-ios/src/pl/mk5/gdx/fireapp/ios/auth/AppleAuth.java
@@ -51,11 +51,11 @@ public class AppleAuth implements AppleAuthDistribution {
             public void accept(final FuturePromise<GdxFirebaseUser> gdxFirebaseUserFuturePromise) {
                 ASAuthorizationAppleIDProvider appleIDProvider = new ASAuthorizationAppleIDProvider();
                 ASAuthorizationAppleIDRequest request = appleIDProvider.createRequest();
-                String nonce = hash256(UUID.randomUUID().toString());
+                String rawNonce = UUID.randomUUID().toString()
                 request.setRequestedScopes(NSArray.fromStrings(SCOPES));
-                request.setNonce(nonce);
+                request.setNonce(hash256(rawNonce));
                 ASAuthorizationController asAuthorizationController = new ASAuthorizationController(new NSArray<ASAuthorizationRequest>(request));
-                asAuthorizationController.setDelegate(new AppleAuthProvider(nonce, gdxFirebaseUserFuturePromise));
+                asAuthorizationController.setDelegate(new AppleAuthProvider(rawNonce, gdxFirebaseUserFuturePromise));
                 asAuthorizationController.setPresentationContextProvider(new ApplePresentationContextProvider());
                 asAuthorizationController.performRequests();
             }

--- a/gdx-fireapp-ios/src/pl/mk5/gdx/fireapp/ios/auth/AppleAuthProvider.java
+++ b/gdx-fireapp-ios/src/pl/mk5/gdx/fireapp/ios/auth/AppleAuthProvider.java
@@ -46,7 +46,8 @@ class AppleAuthProvider extends ASAuthorizationControllerDelegateAdapter {
     public void didComplete(ASAuthorizationController asAuthorizationController, ASAuthorization asAuthorization) {
         if (asAuthorization.getCredential() instanceof ASAuthorizationAppleIDCredential) {
             ASAuthorizationAppleIDCredential credential = (ASAuthorizationAppleIDCredential) asAuthorization.getCredential();
-            FIROAuthCredential firoAuthCredential = FIROAuthProvider.createUsingIDToken(PROVIDER, credential.getIdentityToken().toString(), nonce);
+            String idToken = new String(credential.getIdentityToken().getBytes(), StandardCharsets.UTF_8);
+            FIROAuthCredential firoAuthCredential = FIROAuthProvider.createUsingIDToken(PROVIDER, idToken, nonce);
             FIRAuth.auth().signInUsingCredential(firoAuthCredential, new VoidBlock2<FIRAuthDataResult, NSError>() {
                 @Override
                 public void invoke(FIRAuthDataResult firAuthDataResult, NSError nsError) {


### PR DESCRIPTION
ref: https://firebase.google.com/docs/auth/ios/apple#objective-c_3

There are two issues with signIn with apple which this CR is fixing:
1. credential.getIdentityToken() returns an object of `NSData` and using toString() converts it to a string which is not a valid IdToken which causes an error `unable to parse ID Token`

Fix: Converted it to String using byte data, and correct UTF encoding same as the ref mentioned above.

2. With the above fix, there was issue in validating the nonce, as we are sending sha256 of nonce in request and the same in validation. But instead of sha256 we need to pass the raw nonce so the validation is done correctly.

Fix: Passed raw nonce in delegate

Testing:
1. Validated apple login to be working